### PR TITLE
Fix metadata notFound handling

### DIFF
--- a/app/magazine/[title]/page.tsx
+++ b/app/magazine/[title]/page.tsx
@@ -3,6 +3,7 @@ import PostNavigation from "@/components/PostNavigation";
 import SocialSharing from "@/components/SocialSharing";
 import Subheading from "@/components/Subheading";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 
 export async function generateMetadata({
   params,
@@ -16,7 +17,7 @@ export async function generateMetadata({
   );
 
   if (!articleData) {
-    return <p>Article not found</p>;
+    notFound();
   }
 
   const matchingArticle = articleData.articles.find(
@@ -41,7 +42,7 @@ export default async function ArticleDetails({
     );
 
     if (!articleData) {
-      return <p>Article not found</p>;
+      notFound();
     }
 
     const matchingArticle = articleData.articles.find(
@@ -58,11 +59,7 @@ export default async function ArticleDetails({
       .slice(0, 3);
 
     if (!matchingArticle) {
-      return (
-        <main className="max-w-[95rem] w-full mx-auto px-4 sm:pt-4 xs:pt-2 lg:pb-4 md:pb-4 sm:pb-2 xs:pb-2">
-          <p>Article not found</p>;
-        </main>
-      );
+      notFound();
     }
 
     return (

--- a/app/podcasts/[title]/page.tsx
+++ b/app/podcasts/[title]/page.tsx
@@ -3,6 +3,7 @@ import LatestPodcasts from "@/components/LatestPodcasts/LatestPodcasts";
 import PostNavigation from "@/components/PostNavigation";
 import SocialSharing from "@/components/SocialSharing";
 import PodcastContextProvider from "@/context/PodcastContext";
+import { notFound } from "next/navigation";
 
 export async function generateMetadata({
   params,
@@ -16,7 +17,7 @@ export async function generateMetadata({
   );
 
   if (!podcastData) {
-    return <div>No matching podcast found</div>;
+    notFound();
   }
 
   return {
@@ -37,7 +38,7 @@ export default async function PodcastDetails({
     );
 
     if (!podcastData) {
-      return <div>No matching podcast found</div>;
+      notFound();
     }
 
     return (

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "rd /s /Q .next && next dev",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## Summary
- use `next/navigation` notFound helper in article and podcast routes
- update dev script for cross-platform compatibility

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_687f7831da4883309dac735dadd23101