### PR TITLE
Fix Next.js image domain configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  images: {
+    domains: ['via.placeholder.com'],
+  },
+}
 
 module.exports = nextConfig


### PR DESCRIPTION
## Summary
- allow via.placeholder.com for remote images in Next.js config

## Testing
- `npm run lint`
- `npm run build` *(fails: Type error in app/authors/[author]/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_687f82db1a848330923bce8e643dea98