### PR TITLE
Add domain check page

### DIFF
--- a/app/api/check-domain/route.ts
+++ b/app/api/check-domain/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const domain = searchParams.get("domain");
+
+  if (!domain) {
+    return NextResponse.json(
+      { error: "Missing domain parameter" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const res = await fetch(
+      `https://api.domainsdb.info/v1/domains/search?domain=${encodeURIComponent(domain)}`,
+      { next: { revalidate: 0 } }
+    );
+
+    if (!res.ok) {
+      throw new Error("Failed to fetch");
+    }
+
+    const data = await res.json();
+    const taken = (data?.domains ?? []).some(
+      (d: any) => d.domain.toLowerCase() === domain.toLowerCase()
+    );
+
+    return NextResponse.json({ available: !taken });
+  } catch (e) {
+    return NextResponse.json(
+      { error: "Error checking domain" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/domain/DomainChecker.tsx
+++ b/app/domain/DomainChecker.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+export default function DomainChecker() {
+  const [domain, setDomain] = useState('');
+  const [result, setResult] = useState<null | boolean>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const checkDomain = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!domain) return;
+    setLoading(true);
+    setResult(null);
+    setError('');
+    try {
+      const res = await fetch(`/api/check-domain?domain=${encodeURIComponent(domain)}`);
+      if (!res.ok) throw new Error('Failed');
+      const data = await res.json();
+      setResult(data.available);
+    } catch (err) {
+      setError('Не удалось проверить домен');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={checkDomain} className="flex flex-col gap-4 max-w-sm">
+      <Input
+        placeholder="example.com"
+        value={domain}
+        onChange={(e) => setDomain(e.target.value)}
+      />
+      <Button type="submit" disabled={loading || !domain}>
+        {loading ? 'Проверка...' : 'Проверить'}
+      </Button>
+      {result !== null && (
+        <p className="mt-4">{result ? 'Домен свободен' : 'Домен занят'}</p>
+      )}
+      {error && <p className="mt-4 text-red-600">{error}</p>}
+    </form>
+  );
+}

--- a/app/domain/page.tsx
+++ b/app/domain/page.tsx
@@ -1,0 +1,18 @@
+import PageTitle from '@/components/PageTitle';
+import DomainChecker from './DomainChecker';
+
+export const metadata = {
+  title: 'Домен',
+  description: 'Проверка свободен ли домен',
+};
+
+export default function DomainPage() {
+  return (
+    <main className="flex flex-col min-h-screen max-w-[95rem] w-full mx-auto px-4 py-8">
+      <PageTitle className="text-subtitle" imgSrc="" imgAlt="">
+        Проверка домена
+      </PageTitle>
+      <DomainChecker />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add API route to query domain availability via DomainsDB
- add `DomainChecker` client component
- add `/domain` page for checking domain availability

## Testing
- `npm run lint`
- `npm run build` *(fails: app/podcasts/[title]/page.tsx is not a module)*
- `npm run test:e2e` *(fails: ENETUNREACH errors)*

------
https://chatgpt.com/codex/tasks/task_e_68800941644c8330ab19075f6d6eed94