### PR TITLE
Update screenshot provider

### DIFF
--- a/json/articles.json
+++ b/json/articles.json
@@ -20,12 +20,12 @@
         "date": "Март 2025",
         "read": "2 mins",
         "label": "Корпоративный",
-        "img": "https://dummyimage.com/600x400.png?text=cstbi.ru",
+        "img": "https://mini.s-shot.ru/600x400/JPEG/600/Z100/?https%3A%2F%2Fcstbi.ru",
         "imgAlt": "Screenshot of cstbi.ru",
         "slug": "cstbi",
         "content": [
           {
-            "img": "https://dummyimage.com/1488x992.png?text=cstbi.ru",
+            "img": "https://mini.s-shot.ru/1488x992/JPEG/1488/Z100/?https%3A%2F%2Fcstbi.ru",
             "summary": "Описание проекта и его цели."
           },
           {
@@ -53,12 +53,12 @@
         "date": "Февраль 2025",
         "read": "2 mins",
         "label": "Лендинг",
-        "img": "https://dummyimage.com/600x400.png?text=begovclt.ru",
+        "img": "https://mini.s-shot.ru/600x400/JPEG/600/Z100/?https%3A%2F%2Fbegovclt.ru",
         "imgAlt": "Screenshot of begovclt.ru",
         "slug": "begovclt",
         "content": [
           {
-            "img": "https://dummyimage.com/1488x992.png?text=begovclt.ru",
+            "img": "https://mini.s-shot.ru/1488x992/JPEG/1488/Z100/?https%3A%2F%2Fbegovclt.ru",
             "summary": "Лендинг, описывающий консалтинговое агенство."
           },
           {
@@ -86,12 +86,12 @@
         "date": "Сентябрь 2021",
         "read": "2 mins",
         "label": "Корпоративный",
-        "img": "https://dummyimage.com/600x400.png?text=buhsec.ru",
+        "img": "https://mini.s-shot.ru/600x400/JPEG/600/Z100/?https%3A%2F%2Fbuhsec.ru",
         "imgAlt": "Screenshot of buhsec.ru",
         "slug": "buhsec",
         "content": [
           {
-            "img": "https://dummyimage.com/1488x992.png?text=buhsec.ru",
+            "img": "https://mini.s-shot.ru/1488x992/JPEG/1488/Z100/?https%3A%2F%2Fbuhsec.ru",
             "summary": "Витрина услуг и формы обратной связи."
           },
           {
@@ -119,12 +119,12 @@
         "date": "Январь 2024",
         "read": "2 mins",
         "label": "Лендинг",
-        "img": "https://dummyimage.com/600x400.png?text=vpwallet.io",
+        "img": "https://mini.s-shot.ru/600x400/JPEG/600/Z100/?https%3A%2F%2Fvpwallet.io",
         "imgAlt": "Screenshot of vpwallet.io",
         "slug": "vpwallet",
         "content": [
           {
-            "img": "https://dummyimage.com/1488x992.png?text=vpwallet.io",
+            "img": "https://mini.s-shot.ru/1488x992/JPEG/1488/Z100/?https%3A%2F%2Fvpwallet.io",
             "summary": "Раскрывает возможности кошелька."
           },
           {
@@ -152,12 +152,12 @@
         "date": "Май 2020",
         "read": "14 mins",
         "label": "Корпоративный",
-        "img": "https://dummyimage.com/600x400.png?text=msk-sarmat.ru",
+        "img": "https://mini.s-shot.ru/600x400/JPEG/600/Z100/?https%3A%2F%2Fmsk-sarmat.ru",
         "imgAlt": "Screenshot of msk-sarmat.ru",
         "slug": "msksarmat",
         "content": [
           {
-            "img": "https://dummyimage.com/1488x992.png?text=msk-sarmat.ru",
+            "img": "https://mini.s-shot.ru/1488x992/JPEG/1488/Z100/?https%3A%2F%2Fmsk-sarmat.ru",
             "summary": "Информация об услугах и лицензиях."
           },
           {
@@ -185,12 +185,12 @@
         "date": "Декабрь 2023",
         "read": "2 mins",
         "label": "Корпоративный",
-        "img": "https://dummyimage.com/600x400.png?text=rusalmix.ru",
+        "img": "https://mini.s-shot.ru/600x400/JPEG/600/Z100/?https%3A%2F%2Frusalmix.ru",
         "imgAlt": "Screenshot of rusalmix.ru",
         "slug": "rusalmix",
         "content": [
           {
-            "img": "https://dummyimage.com/1488x992.png?text=rusalmix.ru",
+            "img": "https://mini.s-shot.ru/1488x992/JPEG/1488/Z100/?https%3A%2F%2Frusalmix.ru",
             "summary": "Каталог продукции с фильтрами."
           },
           {
@@ -218,12 +218,12 @@
         "date": "июнь 2018",
         "read": "2 mins",
         "label": "Интернет-магазин",
-        "img": "https://dummyimage.com/600x400.png?text=dveribrend.ru",
+        "img": "https://mini.s-shot.ru/600x400/JPEG/600/Z100/?https%3A%2F%2Fdveribrend.ru",
         "imgAlt": "Screenshot of rusalmix.ru",
         "slug": "dveribrend",
         "content": [
           {
-            "img": "https://dummyimage.com/1488x992.png?text=dveribrend.ru",
+            "img": "https://mini.s-shot.ru/1488x992/JPEG/1488/Z100/?https%3A%2F%2Fdveribrend.ru",
             "summary": "Интернет-магазин дверей с фильтрами и корзиной."
           },
           {

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   images: {
   
-    domains: ['dummyimage.com'],
+    domains: ['mini.s-shot.ru'],
   },
 }
 


### PR DESCRIPTION
## Summary
- update allowed image host to `mini.s-shot.ru`
- switch all article screenshot links from `dummyimage.com` to `mini.s-shot.ru`

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: ENETUNREACH during fetch)*

------
https://chatgpt.com/codex/tasks/task_e_68800bb4c4588330a9bc0ce306df67eb