### PR TITLE
Update Russian texts and services page

### DIFF
--- a/app/authors/[author]/page.tsx
+++ b/app/authors/[author]/page.tsx
@@ -40,7 +40,7 @@ export async function generateMetadata({
 
   if (!authorData) {
     return {
-      title: "Автор не найден",
+      title: "Разработчик не найден",
     };
   }
 
@@ -61,12 +61,12 @@ export default async function AuthorDetails({
 
     const authorData = authors.find((author) => author.slug === decodedAuthor);
     if (!authorData) {
-      return <p>Автор не найден</p>;
+      return <p>Разработчик не найден</p>;
     }
 
     return (
       <main className="max-w-[95rem] w-full mx-auto px-4 sm:pt-4 xs:pt-2 lg:pb-4 md:pb-4 sm:pb-2 xs:pb-2">
-        <PostNavigation href="/authors">Авторы</PostNavigation>
+        <PostNavigation href="/authors">Разработчики</PostNavigation>
         <article className="max-w-[75rem] w-full mx-auto grid lg:grid-cols-[300px_680px] gap-8 md:gap-6 justify-around">
           <div className="w-fit">
             <img src={authorData.avatar} alt={authorData.imgAlt} />
@@ -106,7 +106,7 @@ export default async function AuthorDetails({
         </article>
         <div className="pb-12 md:pb-48">
           <h2 className="text-blog-subheading mt-[9.5rem] pt-12 pb-12 md:pb-24">
-            Работы автора {authorData.author}
+            Работы разработчика {authorData.author}
           </h2>
           <AuthorArticles articles={authorData.articles} />
         </div>

--- a/app/authors/page.tsx
+++ b/app/authors/page.tsx
@@ -4,8 +4,8 @@ import { Suspense } from "react";
 import Loading from "./loading";
 
 export const metadata = {
-  title: "Авторы",
-  description: "Наши авторы",
+  title: "Разработчики",
+  description: "Наши разработчики",
 };
 
 export default function AuthorsPage() {
@@ -14,9 +14,9 @@ export default function AuthorsPage() {
       <PageTitle
         className="sr-only"
         imgSrc="/images/titles/Authors.svg"
-        imgAlt="Слово 'Автор' крупными буквами"
+        imgAlt="Слово 'Разработчик' крупными буквами"
       >
-        Авторы
+        Разработчики
       </PageTitle>
       <Suspense fallback={<Loading />}>
         <AuthorsList />

--- a/app/magazine/[title]/page.tsx
+++ b/app/magazine/[title]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({
   );
 
   return {
-    title: `${matchingArticle?.title} | Portfolio`,
+    title: `${matchingArticle?.title} | Портфолио`,
   };
 }
 
@@ -64,7 +64,7 @@ export default async function ArticleDetails({
 
     return (
       <main className="max-w-[95rem] w-full mx-auto px-4 md:pt-8 sm:pt-4 xs:pt-2 lg:pb-4 md:pb-4 sm:pb-2 xs:pb-2">
-        <PostNavigation href="/magazine">Portfolio</PostNavigation>
+        <PostNavigation href="/magazine">Портфолио</PostNavigation>
         <article className="grid md:grid-cols-2 gap-6 md:gap-6 pb-6 md:pb-24">
           <h2 className="text-subtitle">{matchingArticle.title}</h2>
           <p>{matchingArticle.description}</p>
@@ -72,7 +72,7 @@ export default async function ArticleDetails({
         <div className="flex flex-col md:flex-row justify-between gap-6 md:gap-0 mb-8">
           <div className="flex flex-col sm:flex-row md:items-center gap-2 sm:gap-6">
             <span className="flex flex-wrap">
-              <p className="font-semibold pr-2">Автор</p>
+              <p className="font-semibold pr-2">Разработчик</p>
               <p>{articleData.author}</p>
             </span>
             <span className="flex flex-wrap">
@@ -80,10 +80,6 @@ export default async function ArticleDetails({
               <time dateTime={matchingArticle.date}>
                 {matchingArticle.date}
               </time>
-            </span>
-            <span className="flex flex-wrap">
-              <p className="font-semibold pr-2">Чтение</p>
-              <p>{matchingArticle.read}</p>
             </span>
           </div>
           <span className="px-3 py-2 border border-black rounded-full w-fit">
@@ -118,11 +114,7 @@ export default async function ArticleDetails({
                 </time>
               </div>
               <div className="flex flex-wrap justify-between">
-                <p className="font-semibold">Чтение</p>
-                <p>{matchingArticle.read}</p>
-              </div>
-              <div className="flex flex-wrap justify-between">
-                <p className="flex font-semibold">Share</p>
+                <p className="flex font-semibold">Поделиться</p>
                 <SocialSharing
                   links={[
                     {
@@ -172,7 +164,7 @@ export default async function ArticleDetails({
             url="/magazine"
             linkText="Смотреть все"
           >
-            Последние статьи
+            Последние работы
           </Subheading>
           {latestArticles.map((latestArticles) => (
             <div key={latestArticles.slug}>
@@ -209,7 +201,7 @@ export default async function ArticleDetails({
                 <p className="mt-3 mb-12">{latestArticle.description}</p>
                 <div className="flex flex-wrap gap-4">
                   <span className="flex">
-                    <p className="font-semibold pr-2">Автор</p>
+                    <p className="font-semibold pr-2">Разработчик</p>
                     <p>{articleData.author}</p>
                   </span>
                   <span className="flex">

--- a/app/magazine/page.tsx
+++ b/app/magazine/page.tsx
@@ -4,7 +4,7 @@ import PageTitle from "@/components/PageTitle";
 import { Suspense } from "react";
 
 export const metadata = {
-  title: "Portfolio",
+  title: "Портфолио",
   description: "Completed case studies",
 };
 
@@ -12,7 +12,7 @@ export default function MagazinePage() {
   return (
     <main className="flex flex-col min-h-screen max-w-[95rem] w-full mx-auto px-4 lg:pt-0 sm:pt-4 xs:pt-2 lg:pb-4 md:pb-4 sm:pb-2 xs:pb-2">
       <PageTitle className="sr-only" imgSrc="" imgAlt="">
-        Portfolio
+        Портфолио
       </PageTitle>
       <Suspense fallback={<Loading />}>
         <Articles />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,7 +47,7 @@ export default function Home() {
         url="/authors"
         linkText="Все разработчики"
       >
-        Авторы
+        Разработчики
       </Subheading>
 
       <Suspense fallback={<AuthorsLoading />}>

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,5 +1,7 @@
 import PageTitle from "@/components/PageTitle";
 
+const bulletIcon = "/icons/ri_arrow-right-line.svg";
+
 export const metadata = {
   title: "Услуги",
   description: "Услуги веб-разработчика",
@@ -11,73 +13,105 @@ export default function ServicesPage() {
       <PageTitle className="text-subtitle" imgSrc="" imgAlt="">
         Услуги веб-разработчика
       </PageTitle>
-      <div className="prose max-w-none">
+      <div className="prose max-w-none space-y-8">
         <h2>1. Разработка сайтов</h2>
-        <ul>
-          <li>Лендинги (Landing Page)</li>
-          <li>Корпоративные сайты</li>
-          <li>Интернет-магазины</li>
-          <li>Многостраничные сайты (каталоги, порталы)</li>
-          <li>Сайты-визитки</li>
-          <li>SPA-приложения (Single Page Application)</li>
-          <li>Административные панели и личные кабинеты</li>
+        <ul className="space-y-2">
+          <li className="flex gap-2">
+            <img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Лендинги (Landing Page)
+          </li>
+          <li className="flex gap-2">
+            <img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Корпоративные сайты
+          </li>
+          <li className="flex gap-2">
+            <img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Интернет-магазины
+          </li>
+          <li className="flex gap-2">
+            <img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Многостраничные сайты (каталоги, порталы)
+          </li>
+          <li className="flex gap-2">
+            <img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Сайты-визитки
+          </li>
+          <li className="flex gap-2">
+            <img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />SPA-приложения (Single Page Application)
+          </li>
+          <li className="flex gap-2">
+            <img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Административные панели и личные кабинеты
+          </li>
         </ul>
         <h2>2. Дизайн и UX/UI</h2>
-        <ul>
-          <li>Прототипирование интерфейсов (Wireframes, UX-сценарии)</li>
-          <li>Дизайн-макеты (Figma, Adobe XD, Sketch)</li>
-          <li>Мобильная и десктопная адаптация</li>
-          <li>UI-анимации (CSS, SVG, Lottie)</li>
+        <ul className="space-y-2">
+          <li className="flex gap-2">
+            <img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Прототипирование интерфейсов (Wireframes, UX-сценарии)
+          </li>
+          <li className="flex gap-2">
+            <img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Дизайн-макеты (Figma, Adobe XD, Sketch)
+          </li>
+          <li className="flex gap-2">
+            <img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Мобильная и десктопная адаптация
+          </li>
+          <li className="flex gap-2">
+            <img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />UI-анимации (CSS, SVG, Lottie)
+          </li>
         </ul>
         <h2>3. Фронтенд-разработка</h2>
-        <ul>
-          <li>Верстка по макетам (HTML5, CSS3, SCSS)</li>
-          <li>Кроссбраузерность и адаптивность (Media Queries, Flexbox, Grid)</li>
-          <li>JavaScript и библиотеки: Vanilla JS, jQuery (по требованию)</li>
-          <li>Фреймворки: React.js, Vue.js, Next.js (SSR и SSG), Nuxt.js</li>
-          <li>Интерактивные элементы: слайдеры, табы, модальные окна, кастомные формы</li>
+        <ul className="space-y-2">
+          <li className="flex gap-2">
+            <img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Верстка по макетам (HTML5, CSS3, SCSS)
+          </li>
+          <li className="flex gap-2">
+            <img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Кроссбраузерность и адаптивность (Media Queries, Flexbox, Grid)
+          </li>
+          <li className="flex gap-2">
+            <img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />JavaScript и библиотеки: Vanilla JS, jQuery (по требованию)
+          </li>
+          <li className="flex gap-2">
+            <img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Фреймворки: React.js, Vue.js, Next.js (SSR и SSG), Nuxt.js
+          </li>
+          <li className="flex gap-2">
+            <img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Интерактивные элементы: слайдеры, табы, модальные окна, кастомные формы
+          </li>
         </ul>
         <h2>4. Бэкенд-разработка</h2>
-        <ul>
-          <li>Node.js (Express.js, Nest.js)</li>
-          <li>PHP (Laravel, Yii2, WordPress)</li>
-          <li>Python (Django, FastAPI)</li>
-          <li>API: REST API, GraphQL</li>
-          <li>Базы данных: MySQL, PostgreSQL, MongoDB, Firebase</li>
-          <li>CMS: WordPress, 1С-Битрикс, Strapi, Sanity, Netlify CMS</li>
+        <ul className="space-y-2">
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Node.js (Express.js, Nest.js)</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />PHP (Laravel, Yii2, WordPress)</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Python (Django, FastAPI)</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />API: REST API, GraphQL</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Базы данных: MySQL, PostgreSQL, MongoDB, Firebase</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />CMS: WordPress, 1С-Битрикс, Strapi, Sanity, Netlify CMS</li>
         </ul>
         <h2>5. Интеграции</h2>
-        <ul>
-          <li>Платежные системы (Stripe, ЮKassa, PayPal)</li>
-          <li>Онлайн-чаты (JivoSite, Tawk.to, Telegram Bot)</li>
-          <li>CRM-системы (Bitrix24, amoCRM, МойСклад)</li>
-          <li>Email-рассылки (Sendinblue, Mailchimp)</li>
-          <li>Карты (Google Maps, Яндекс.Карты)</li>
-          <li>Формы и заявки с отправкой на email/Telegram</li>
+        <ul className="space-y-2">
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Платежные системы (Stripe, ЮKassa, PayPal)</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Онлайн-чаты (JivoSite, Tawk.to, Telegram Bot)</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />CRM-системы (Bitrix24, amoCRM, МойСклад)</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Email-рассылки (Sendinblue, Mailchimp)</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Карты (Google Maps, Яндекс.Карты)</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Формы и заявки с отправкой на email/Telegram</li>
         </ul>
         <h2>6. SEO и производительность</h2>
-        <ul>
-          <li>Базовая SEO-оптимизация (meta, schema.org, robots.txt, sitemap.xml)</li>
-          <li>Повышение скорости загрузки (Google PageSpeed, lazy loading, image/webp)</li>
-          <li>Оптимизация и минификация кода</li>
-          <li>OpenGraph и адаптация для соцсетей</li>
+        <ul className="space-y-2">
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Базовая SEO-оптимизация (meta, schema.org, robots.txt, sitemap.xml)</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Повышение скорости загрузки (Google PageSpeed, lazy loading, image/webp)</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Оптимизация и минификация кода</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />OpenGraph и адаптация для соцсетей</li>
         </ul>
         <h2>7. Хостинг, DevOps и поддержка</h2>
-        <ul>
-          <li>Настройка хостинга (VPS, Vercel, Netlify, Timeweb, Jino)</li>
-          <li>Установка и настройка SSL-сертификатов</li>
-          <li>Развёртывание и CI/CD (GitHub Actions, Docker)</li>
-          <li>Поддержка, обновления и мониторинг</li>
-          <li>Настройка резервного копирования</li>
+        <ul className="space-y-2">
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Настройка хостинга (VPS, Vercel, Netlify, Timeweb, Jino)</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Установка и настройка SSL-сертификатов</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Развёртывание и CI/CD (GitHub Actions, Docker)</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Поддержка, обновления и мониторинг</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Настройка резервного копирования</li>
         </ul>
         <h2>8. Дополнительные услуги</h2>
-        <ul>
-          <li>Миграция сайта на новую платформу</li>
-          <li>Рефакторинг и улучшение кода</li>
-          <li>Аудит текущего сайта</li>
-          <li>Автоматизация задач (например, выгрузка товаров из 1С)</li>
-          <li>Создание Telegram-ботов</li>
-          <li>Разработка Progressive Web App (PWA)</li>
+        <ul className="space-y-2">
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Миграция сайта на новую платформу</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Рефакторинг и улучшение кода</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Аудит текущего сайта</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Автоматизация задач (например, выгрузка товаров из 1С)</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Создание Telegram-ботов</li>
+          <li className="flex gap-2"><img src={bulletIcon} alt="" className="w-4 h-4 mt-1" />Разработка Progressive Web App (PWA)</li>
         </ul>
       </div>
     </main>

--- a/components/Articles/Articles.tsx
+++ b/components/Articles/Articles.tsx
@@ -73,7 +73,7 @@ export default function Articles() {
             <p className="mt-3 mb-12">{articleData.description}</p>
             <div className="flex flex-wrap gap-4">
               <span className="flex">
-                <p className="font-semibold pr-2">Автор</p>
+                <p className="font-semibold pr-2">Разработчик</p>
                 <p>{articleData.author}</p>
               </span>
              

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -42,8 +42,8 @@ export default function Footer() {
                 <li>
                   <Link href="/services">Услуги</Link>
                 </li>
-                 <li>
-                  <Link href="/authors">Авторы</Link>
+                <li>
+                  <Link href="/authors">Разработчики</Link>
                 </li>
               </ul>
             </nav>
@@ -53,7 +53,7 @@ export default function Footer() {
                   <a href="/brief">Бриф</a>
                 </li>
                 <li>
-                  <a href="#">Проверить домен</a>
+                  <Link href="/domain">Домен</Link>
                 </li>
                
               </ul>

--- a/components/LatestArticles.tsx
+++ b/components/LatestArticles.tsx
@@ -33,16 +33,12 @@ export default function LatestArticles() {
               <div className="flex flex-wrap justify-between items-center gap-2">
                 <div className="flex flex-wrap gap-2 sm:gap-6">
                   <span className="flex flex-wrap">
-                    <p className="font-semibold pr-2">Автор</p>
+                    <p className="font-semibold pr-2">Разработчик</p>
                     <p>{data[0].author}</p>
                   </span>
                   <span className="flex flex-wrap">
                     <p className="font-semibold pr-2">Дата</p>
                     <p>{data[0].articles[0].date}</p>
-                  </span>
-                  <span className="flex flex-wrap">
-                    <p className="font-semibold pr-2">Чтение</p>
-                    <p>{data[0].articles[0].read}</p>
                   </span>
                 </div>
                 <span className="px-3 py-2 border border-black rounded-full">
@@ -85,16 +81,12 @@ export default function LatestArticles() {
                     <div className="flex flex-wrap gap-4 justify-between items-center">
                       <div className="flex gap-6">
                         <span className="flex flex-wrap">
-                          <p className="font-semibold pr-2">Автор</p>
+                          <p className="font-semibold pr-2">Разработчик</p>
                           <p>{data[0].author}</p>
                         </span>
                         <span className="flex flex-wrap">
                           <p className="font-semibold pr-2">Дата</p>
                           <p>{article.date}</p>
-                        </span>
-                        <span className="flex flex-wrap">
-                          <p className="font-semibold pr-2">Чтение</p>
-                          <p>{article.read}</p>
                         </span>
                       </div>
                       <span className="px-3 py-2 border border-black rounded-full">

--- a/components/LatestArticles/LatestArticles.tsx
+++ b/components/LatestArticles/LatestArticles.tsx
@@ -36,7 +36,7 @@ export default function LatestArticles() {
                 <div className="flex flex-col sm:flex-row justify-between sm:items-center gap-2">
                   <div className="flex flex-col sm:flex-row gap-2 sm:gap-6">
                     <span className="flex flex-wrap">
-                      <p className="font-semibold pr-2">Автор</p>
+                      <p className="font-semibold pr-2">Разработчик</p>
                       <p>{data[0].author}</p>
                     </span>
                     <span className="flex flex-wrap">
@@ -93,7 +93,7 @@ export default function LatestArticles() {
                     <div className="flex flex-col sm:flex-row gap-4 justify-between sm:items-center">
                       <div className="flex flex-col sm:flex-row gap-2 sm:gap-6">
                         <span className="flex flex-wrap">
-                          <p className="font-semibold pr-2">Автор</p>
+                          <p className="font-semibold pr-2">Разработчик</p>
                           <p>{data[0].author}</p>
                         </span>
                         <span className="flex flex-wrap">

--- a/data/menu.ts
+++ b/data/menu.ts
@@ -16,6 +16,10 @@ const menu: MenuItem[] = [
     href: "/brief",
     label: "Бриф",
   },
+  {
+    href: "/domain",
+    label: "Домен",
+  },
 ];
 
 export default menu;


### PR DESCRIPTION
## Summary
- translate labels from "автор" to "разработчик"
- change portfolio texts to "Портфолио"
- remove reading time labels
- rename "Share" to "Поделиться"
- add domain page link to menu and footer
- beautify services page with icons and spacing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6880a58943f48330b11a67379b1aca88