### PR TITLE
Add bottom padding for page titles

### DIFF
--- a/app/brief/page.tsx
+++ b/app/brief/page.tsx
@@ -57,7 +57,7 @@ export default function BriefPage() {
 
   return (
     <main className="max-w-[95rem] w-full mx-auto px-4 py-8">
-      <h1 className="text-subtitle mb-6">Бриф на разработку сайта</h1>
+      <h1 className="text-subtitle mb-6 pb-6">Бриф на разработку сайта</h1>
       <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-6 max-w-xl">
         {step === 1 && (
           <div className="flex flex-col gap-4">

--- a/app/domain/page.tsx
+++ b/app/domain/page.tsx
@@ -9,7 +9,7 @@ export const metadata = {
 export default function DomainPage() {
   return (
     <main className="flex flex-col min-h-screen max-w-[95rem] w-full mx-auto px-4 py-8">
-      <PageTitle className="text-subtitle" imgSrc="" imgAlt="">
+      <PageTitle className="text-subtitle pb-6" imgSrc="" imgAlt="">
         Проверка домена
       </PageTitle>
       <DomainChecker />

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -96,7 +96,7 @@ const services = [
 export default function ServicesPage() {
   return (
     <main className="flex flex-col min-h-screen max-w-[95rem] w-full mx-auto px-4 lg:pt-0 sm:pt-4 xs:pt-2 lg:pb-4 md:pb-4 sm:pb-2 xs:pb-2">
-      <PageTitle className="text-subtitle" imgSrc="" imgAlt="">
+      <PageTitle className="text-subtitle pb-6" imgSrc="" imgAlt="">
         Услуги веб-разработчика
       </PageTitle>
  <div className="grid grid-cols-1 md:grid-cols-2 border border-black border-collapse mb-48">


### PR DESCRIPTION
## Summary
- add pb-6 under Services, Domain, and Brief page titles

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: Playwright browser dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6880b4c621f88330b5cbb8862c9ec1af